### PR TITLE
Create dashboard page for logged-in users

### DIFF
--- a/app/actions/profile.ts
+++ b/app/actions/profile.ts
@@ -23,7 +23,6 @@ export type ProfileUpdateRequest = Partial<
 export const updateProfile = async (
   updateRequest: Record<string, unknown>
 ): Promise<ServerActionResponse> => {
-  console.log("reached here");
   const session = await auth();
   if (!session) throw Error("Not authenticated");
   try {

--- a/app/actions/signin.ts
+++ b/app/actions/signin.ts
@@ -2,9 +2,8 @@
 import { signIn as authSignIn } from "@/auth";
 export const signIn = async () => {
   try {
-    await authSignIn("microsoft-entra-id");
+    await authSignIn("microsoft-entra-id", { redirectTo: "/dashboard" });
   } catch (error) {
-    console.log(error);
     throw error;
   }
 };

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,181 +1,19 @@
 "use client";
-import {
-  Stack,
-  Alert,
-  HStack,
-  Link as ChakraLink,
-  Tabs,
-  Card,
-  Text,
-  Badge,
-  Button,
-  IconButton,
-  Strong,
-  SimpleGrid,
-  GridItem,
-  Heading,
-} from "@chakra-ui/react";
+import { Alert, Link as ChakraLink, IconButton } from "@chakra-ui/react";
 import { useSession } from "next-auth/react";
 import NextLink from "next/link";
-import {
-  LuFolder,
-  LuPlus,
-  LuSmile,
-  LuSquareCheck,
-  LuUser,
-  LuX,
-} from "react-icons/lu";
-import { type Session } from "next-auth";
+import { LuSmile, LuX } from "react-icons/lu";
 import { useEffect, useState } from "react";
-import { Avatar } from "../shared/snippets/avatar";
-import { useRouter } from "next/navigation";
-function Friend() {
-  return (
-    <Card.Root
-      width="320px"
-      bg={"accent.muted"}
-      shadow={"sm"}
-      variant={"elevated"}
-    >
-      <Card.Body color="primary.fg" gap={1}>
-        <HStack mb="6" gap="3">
-          <Avatar
-            src="https://images.unsplash.com/photo-1511806754518-53bada35f930"
-            name="Nate Foss"
-          />
-          <Stack gap="0">
-            <Text fontWeight="semibold" textStyle="sm">
-              Nate Foss
-            </Text>
-            <Text textStyle="sm">Machine Learning</Text>
-          </Stack>
-        </HStack>
-        <Card.Description color="primary.fg">
-          <Strong color="fg">Nate Foss </Strong>
-          has requested to join your team. You can approve or decline their
-          request.
-        </Card.Description>
-        <HStack
-          flexWrap={"wrap"}
-          gap="2"
-          mt={2}
-          borderTop="solid 1px"
-          borderColor="primary.fg/30"
-          pt={3}
-        >
-          <Badge textTransform={"lowercase"} shadow={"xs"}>
-            Klamath Falls
-          </Badge>
-          <Badge textTransform={"lowercase"} shadow={"xs"}>
-            Sophomore
-          </Badge>
-          <Badge
-            colorPalette={"yellow"}
-            variant={"solid"}
-            textTransform={"lowercase"}
-            fontWeight="bold"
-            shadow={"xs"}
-            letterSpacing={"wide"}
-          >
-            perfect availability!
-          </Badge>
-          <Badge
-            colorPalette={"blue"}
-            variant={"solid"}
-            textTransform={"lowercase"}
-            fontWeight="bold"
-            shadow={"xs"}
-            letterSpacing={"wide"}
-          >
-            close by
-          </Badge>
-        </HStack>
-      </Card.Body>
-      <Card.Footer gap="2" flexDirection="column">
-        <Button
-          variant="subtle"
-          p={2}
-          colorPalette="accent"
-          _hover={{ bg: "accent.emphasized" }}
-          flex="1"
-          w="100%"
-          fontFamily={"heading"}
-          fontWeight={"semibold"}
-        >
-          <LuPlus />
-        </Button>
-      </Card.Footer>
-    </Card.Root>
-  );
-}
-function Friends() {
-  return (
-    <Card.Root width="100%" variant={"elevated"} bg={"secondary.muted"}>
-      <Card.Header textAlign={"center"} pb={0}>
-        <Heading size={"3xl"}>study partners</Heading>
-      </Card.Header>
-      <Card.Body gap="2">
-        <Tabs.Root defaultValue="search" variant={"line"}>
-          <Tabs.List>
-            <Tabs.Trigger value="search">
-              <LuUser />
-              Search
-            </Tabs.Trigger>
-            <Tabs.Trigger value="projects">
-              <LuFolder />
-              Projects
-            </Tabs.Trigger>
-            <Tabs.Trigger value="tasks">
-              <LuSquareCheck />
-              Settings
-            </Tabs.Trigger>
-          </Tabs.List>
-          <Tabs.Content value="search" alignItems={"center"}>
-            <SimpleGrid
-              columns={[4]}
-              gap="1em"
-              width="min-fit"
-              alignItems={"center"}
-              justifyItems={"center"}
-            >
-              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
-                {" "}
-                <Friend />
-              </GridItem>
-              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
-                {" "}
-                <Friend />
-              </GridItem>
-              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
-                {" "}
-                <Friend />
-              </GridItem>
-              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
-                {" "}
-                <Friend />
-              </GridItem>
-              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
-                {" "}
-                <Friend />
-              </GridItem>
-              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
-                {" "}
-                <Friend />
-              </GridItem>
-            </SimpleGrid>
-          </Tabs.Content>
-          <Tabs.Content value="projects">Manage your projects</Tabs.Content>
-          <Tabs.Content value="tasks">
-            Manage your tasks for freelancers
-          </Tabs.Content>
-        </Tabs.Root>
-      </Card.Body>
-      <Card.Footer justifyContent="flex-end"></Card.Footer>
-    </Card.Root>
-  );
-}
-function WelcomeAlert({ status }: { status: string; session: Session | null }) {
-  const [open, setOpen] = useState(true);
+import { useSelfProfile } from "../swr/profile";
+import StudyPartners from "./study-partners";
+
+function WelcomeAlert({ token }: { token: string | undefined }) {
+  const { data: profile, isLoading } = useSelfProfile(token);
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (!isLoading && !!profile) setOpen(true);
+  }, [isLoading, profile]);
+
   return open ? (
     <Alert.Root status="success" alignItems={"center"}>
       <Alert.Indicator>
@@ -183,7 +21,7 @@ function WelcomeAlert({ status }: { status: string; session: Session | null }) {
       </Alert.Indicator>
       <Alert.Content justifyContent={"center"}>
         <Alert.Title fontSize={"sm"}>Welcome back! 👋🐦</Alert.Title>
-        {status === "authenticated" && true && (
+        {profile!.newAccount && (
           <Alert.Description>
             <ChakraLink
               asChild
@@ -215,15 +53,11 @@ function WelcomeAlert({ status }: { status: string; session: Session | null }) {
   );
 }
 export default function Dashboard() {
-  const { data: session, status } = useSession();
-  const router = useRouter();
-  useEffect(() => {
-    // if (true) router.push("/profile");
-  }, [router]);
+  const { data: session } = useSession();
   return (
     <>
-      <WelcomeAlert status={status} session={session} />
-      <Friends />
+      <WelcomeAlert token={session?.accessToken} />
+      <StudyPartners />
     </>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+import {
+  Stack,
+  Alert,
+  HStack,
+  Link as ChakraLink,
+  Tabs,
+  Card,
+  Text,
+  Badge,
+  Button,
+  IconButton,
+  Strong,
+  SimpleGrid,
+  GridItem,
+  Heading,
+} from "@chakra-ui/react";
+import { useSession } from "next-auth/react";
+import NextLink from "next/link";
+import {
+  LuFolder,
+  LuPlus,
+  LuSmile,
+  LuSquareCheck,
+  LuUser,
+  LuX,
+} from "react-icons/lu";
+import { type Session } from "next-auth";
+import { useEffect, useState } from "react";
+import { Avatar } from "../shared/snippets/avatar";
+import { useRouter } from "next/navigation";
+function Friend() {
+  return (
+    <Card.Root
+      width="320px"
+      bg={"accent.muted"}
+      shadow={"sm"}
+      variant={"elevated"}
+    >
+      <Card.Body color="primary.fg" gap={1}>
+        <HStack mb="6" gap="3">
+          <Avatar
+            src="https://images.unsplash.com/photo-1511806754518-53bada35f930"
+            name="Nate Foss"
+          />
+          <Stack gap="0">
+            <Text fontWeight="semibold" textStyle="sm">
+              Nate Foss
+            </Text>
+            <Text textStyle="sm">Machine Learning</Text>
+          </Stack>
+        </HStack>
+        <Card.Description color="primary.fg">
+          <Strong color="fg">Nate Foss </Strong>
+          has requested to join your team. You can approve or decline their
+          request.
+        </Card.Description>
+        <HStack
+          flexWrap={"wrap"}
+          gap="2"
+          mt={2}
+          borderTop="solid 1px"
+          borderColor="primary.fg/30"
+          pt={3}
+        >
+          <Badge textTransform={"lowercase"} shadow={"xs"}>
+            Klamath Falls
+          </Badge>
+          <Badge textTransform={"lowercase"} shadow={"xs"}>
+            Sophomore
+          </Badge>
+          <Badge
+            colorPalette={"yellow"}
+            variant={"solid"}
+            textTransform={"lowercase"}
+            fontWeight="bold"
+            shadow={"xs"}
+            letterSpacing={"wide"}
+          >
+            perfect availability!
+          </Badge>
+          <Badge
+            colorPalette={"blue"}
+            variant={"solid"}
+            textTransform={"lowercase"}
+            fontWeight="bold"
+            shadow={"xs"}
+            letterSpacing={"wide"}
+          >
+            close by
+          </Badge>
+        </HStack>
+      </Card.Body>
+      <Card.Footer gap="2" flexDirection="column">
+        <Button
+          variant="subtle"
+          p={2}
+          colorPalette="accent"
+          _hover={{ bg: "accent.emphasized" }}
+          flex="1"
+          w="100%"
+          fontFamily={"heading"}
+          fontWeight={"semibold"}
+        >
+          <LuPlus />
+        </Button>
+      </Card.Footer>
+    </Card.Root>
+  );
+}
+function Friends() {
+  return (
+    <Card.Root width="100%" variant={"elevated"} bg={"secondary.muted"}>
+      <Card.Header textAlign={"center"} pb={0}>
+        <Heading size={"3xl"}>study partners</Heading>
+      </Card.Header>
+      <Card.Body gap="2">
+        <Tabs.Root defaultValue="search" variant={"line"}>
+          <Tabs.List>
+            <Tabs.Trigger value="search">
+              <LuUser />
+              Search
+            </Tabs.Trigger>
+            <Tabs.Trigger value="projects">
+              <LuFolder />
+              Projects
+            </Tabs.Trigger>
+            <Tabs.Trigger value="tasks">
+              <LuSquareCheck />
+              Settings
+            </Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="search" alignItems={"center"}>
+            <SimpleGrid
+              columns={[4]}
+              gap="1em"
+              width="min-fit"
+              alignItems={"center"}
+              justifyItems={"center"}
+            >
+              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
+                {" "}
+                <Friend />
+              </GridItem>
+              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
+                {" "}
+                <Friend />
+              </GridItem>
+              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
+                {" "}
+                <Friend />
+              </GridItem>
+              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
+                {" "}
+                <Friend />
+              </GridItem>
+              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
+                {" "}
+                <Friend />
+              </GridItem>
+              <GridItem colSpan={{ base: 4, lg: 2, xl: 1 }}>
+                {" "}
+                <Friend />
+              </GridItem>
+            </SimpleGrid>
+          </Tabs.Content>
+          <Tabs.Content value="projects">Manage your projects</Tabs.Content>
+          <Tabs.Content value="tasks">
+            Manage your tasks for freelancers
+          </Tabs.Content>
+        </Tabs.Root>
+      </Card.Body>
+      <Card.Footer justifyContent="flex-end"></Card.Footer>
+    </Card.Root>
+  );
+}
+function WelcomeAlert({ status }: { status: string; session: Session | null }) {
+  const [open, setOpen] = useState(true);
+  return open ? (
+    <Alert.Root status="success" alignItems={"center"}>
+      <Alert.Indicator>
+        <LuSmile fontWeight={"bold"} fontSize={"lg"} />
+      </Alert.Indicator>
+      <Alert.Content justifyContent={"center"}>
+        <Alert.Title fontSize={"sm"}>Welcome back! 👋🐦</Alert.Title>
+        {status === "authenticated" && true && (
+          <Alert.Description>
+            <ChakraLink
+              asChild
+              fontWeight="bold"
+              letterSpacing={"wide"}
+              color="primary.fg"
+              textAlign={{ mdDown: "center" }}
+              variant={"underline"}
+            >
+              <NextLink href="/profile">
+                Let&apos;s finish up setting your profile.
+              </NextLink>
+            </ChakraLink>
+          </Alert.Description>
+        )}
+      </Alert.Content>
+      <IconButton
+        rounded="full"
+        p={2}
+        variant={"subtle"}
+        onClick={() => setOpen(!open)}
+      >
+        {" "}
+        <LuX />
+      </IconButton>
+    </Alert.Root>
+  ) : (
+    <></>
+  );
+}
+export default function Dashboard() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  useEffect(() => {
+    // if (true) router.push("/profile");
+  }, [router]);
+  return (
+    <>
+      <WelcomeAlert status={status} session={session} />
+      <Friends />
+    </>
+  );
+}

--- a/app/dashboard/profile/condensed-profile.tsx
+++ b/app/dashboard/profile/condensed-profile.tsx
@@ -1,0 +1,50 @@
+import { type Profile } from "@/app/swr/profile";
+import { Card, type UseDialogReturn } from "@chakra-ui/react";
+import ProfileHeader from "./shared/profile-header";
+import Bio from "./shared/bio";
+import Badges from "./shared/badges";
+
+export default function CondensedProfile({
+  profile,
+  dialog,
+}: {
+  profile: Profile;
+  dialog: UseDialogReturn;
+}) {
+  const { standing, campusChoices, bio } = profile;
+  const { setOpen: setDialogOpen } = dialog;
+  return (
+    <Card.Root
+      width="350px"
+      height="325px"
+      bg={"accent.muted"}
+      shadow={"sm"}
+      variant={"elevated"}
+      alignSelf={""}
+    >
+      <Card.Header>
+        <ProfileHeader
+          condensed={true}
+          setDialogOpen={setDialogOpen}
+          profile={profile}
+        />
+      </Card.Header>
+      <Card.Body
+        pb={0}
+        pt={5}
+        color="primary.fg"
+        justifyContent={"space-between"}
+      >
+        <Card.Description color="primary.fg" asChild>
+          <Bio bio={bio} />
+        </Card.Description>
+      </Card.Body>
+      <Card.Footer>
+        <Badges
+          primaryCampus={campusChoices?.[0]?.name}
+          standing={standing?.name}
+        />
+      </Card.Footer>
+    </Card.Root>
+  );
+}

--- a/app/dashboard/profile/full-profile.tsx
+++ b/app/dashboard/profile/full-profile.tsx
@@ -1,0 +1,144 @@
+"use client";
+import {
+  Text,
+  DialogRootProvider,
+  type UseDialogReturn,
+  VStack,
+  Alert,
+  Tabs,
+  useTabs,
+  AccordionItemContent,
+  Heading,
+} from "@chakra-ui/react";
+import {
+  type Timeslot,
+  type Day,
+  type Profile as ProfileType,
+} from "../../swr/profile";
+import {
+  DialogBackdrop,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTrigger,
+} from "../../shared/snippets/dialog";
+import TimeslotTable from "./timeslot-table";
+import { DAYS } from "../../shared/constants";
+import {
+  AccordionItem,
+  AccordionItemTrigger,
+  AccordionRoot,
+} from "../../shared/snippets/accordion";
+import ProfileHeader from "./shared/profile-header";
+import Bio from "./shared/bio";
+import Badges from "./shared/badges";
+function Timeslots({ timeslots }: { timeslots: Record<Day, Timeslot[]> }) {
+  const tabs = useTabs({ defaultValue: DAYS[0] });
+  const dayAbbreviations: Record<Day, string> = {
+    Sunday: "Su",
+    Monday: "M",
+    Tuesday: "T",
+    Wednesday: "W",
+    Thursday: "Th",
+    Friday: "F",
+    Saturday: "Sa",
+  };
+  return (
+    <AccordionRoot collapsible rounded="md" defaultValue={["timeslots"]}>
+      <AccordionItem value="timeslots" border={0}>
+        <AccordionItemTrigger
+          bg="accent.muted/30"
+          _hover={{ bg: "accent.muted/50" }}
+          p={2}
+        >
+          <Heading size="lg">availability</Heading>
+        </AccordionItemTrigger>
+        <AccordionItemContent>
+          <Tabs.RootProvider value={tabs} lazyMount py={4} px={2}>
+            <Tabs.List justifyContent={"space-evenly"} borderColor="gray">
+              {Object.keys(dayAbbreviations).map((day) => {
+                return (
+                  <Tabs.Trigger key={day} value={day}>
+                    <Text hideBelow="md">{day}</Text>
+                    <Text hideFrom="md">{dayAbbreviations[day as Day]}</Text>
+                  </Tabs.Trigger>
+                );
+              })}
+            </Tabs.List>
+            {DAYS.map((day) => (
+              <Tabs.Content key={day} value={day} spaceY={5}>
+                <TimeslotTable timeslotsMap={timeslots} />
+              </Tabs.Content>
+            ))}
+          </Tabs.RootProvider>
+        </AccordionItemContent>
+      </AccordionItem>
+    </AccordionRoot>
+  );
+}
+function TimeslotsFallback() {
+  return (
+    <Alert.Root
+      status="neutral"
+      alignItems={"center"}
+      bg={"secondary.emphasized"}
+      letterSpacing={"wider"}
+      gap={0}
+      flexDir={"column"}
+    >
+      <Alert.Title fontWeight={"semibold"}>study slots unknown</Alert.Title>
+      <Alert.Description>
+        Reach out to ask when they&apos;re available!
+      </Alert.Description>
+    </Alert.Root>
+  );
+}
+export default function FullProfile({
+  profile,
+  dialog,
+}: {
+  profile: ProfileType;
+  dialog: UseDialogReturn;
+}) {
+  const { standing, campusChoices, bio, timeslots } = profile;
+
+  return (
+    <DialogRootProvider
+      value={dialog}
+      placement="center"
+      size={{ mdDown: "cover", base: "lg" }}
+    >
+      <DialogBackdrop />
+      <DialogTrigger />
+      <DialogContent>
+        <DialogCloseTrigger />
+        <DialogHeader>
+          <ProfileHeader condensed={false} profile={profile} />
+        </DialogHeader>
+        <DialogBody
+          pb={0}
+          pt={5}
+          color="primary.fg"
+          justifyContent={"space-between"}
+        >
+          <Bio bio={bio} truncate={false} />
+        </DialogBody>
+        <DialogFooter>
+          <VStack w="full" gap={5}>
+            <Badges
+              primaryCampus={campusChoices?.[0]?.name}
+              standing={standing?.name}
+            />
+            {timeslots ? (
+              <Timeslots timeslots={timeslots} />
+            ) : (
+              <TimeslotsFallback />
+            )}
+          </VStack>
+        </DialogFooter>
+      </DialogContent>
+    </DialogRootProvider>
+  );
+}

--- a/app/dashboard/profile/profile-menu.tsx
+++ b/app/dashboard/profile/profile-menu.tsx
@@ -1,0 +1,26 @@
+import { MenuContent, MenuItem } from "@/app/shared/snippets/menu";
+
+export default function ProfileMenu() {
+  return (
+    <>
+      <MenuContent>
+        <MenuItem
+          fontWeight="semibold"
+          letterSpacing="wider"
+          value="block"
+          _hover={{ bg: "bg.danger" }}
+        >
+          Block 🚫
+        </MenuItem>
+        <MenuItem
+          fontWeight="semibold"
+          letterSpacing="wider"
+          value="report"
+          _hover={{ bg: "bg.danger" }}
+        >
+          Report 🚩
+        </MenuItem>
+      </MenuContent>
+    </>
+  );
+}

--- a/app/dashboard/profile/profile-wrapper.tsx
+++ b/app/dashboard/profile/profile-wrapper.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useDialog, useMenu, MenuRootProvider } from "@chakra-ui/react";
+import { type Profile as ProfileType } from "../../swr/profile";
+import ProfileMenu from "./profile-menu";
+import CondensedProfile from "./condensed-profile";
+import FullProfile from "./full-profile";
+
+export default function ProfileWrapper({ profile }: { profile: ProfileType }) {
+  const dialog = useDialog();
+  const menu = useMenu({
+    positioning: {
+      placement: "bottom-end",
+    },
+  });
+  return (
+    <MenuRootProvider value={menu}>
+      <CondensedProfile profile={profile} dialog={dialog} />
+      <ProfileMenu />
+      <FullProfile profile={profile} dialog={dialog} />
+    </MenuRootProvider>
+  );
+}

--- a/app/dashboard/profile/shared/badges.tsx
+++ b/app/dashboard/profile/shared/badges.tsx
@@ -1,0 +1,40 @@
+import { HStack, Badge } from "@chakra-ui/react";
+export default function Badges({
+  primaryCampus,
+  standing,
+}: {
+  primaryCampus?: string;
+  standing?: string;
+}) {
+  return (
+    <HStack
+      flexWrap={"wrap"}
+      gap="2"
+      mt={2}
+      borderTop="solid 1px"
+      borderColor="primary.fg/30"
+      pt={3}
+      w="full"
+    >
+      <Badge
+        textTransform={"lowercase"}
+        shadow={"xs"}
+        colorPalette={primaryCampus ? "yellow" : "gray"}
+        letterSpacing={"wide"}
+        fontWeight="bold"
+        variant={"solid"}
+      >
+        {primaryCampus ?? "main campus unknown"}
+      </Badge>
+      <Badge
+        textTransform={"lowercase"}
+        colorPalette={standing ? "yellow" : "gray"}
+        letterSpacing={"wide"}
+        fontWeight="bold"
+        variant={"solid"}
+      >
+        {standing ?? "year unknown"}
+      </Badge>
+    </HStack>
+  );
+}

--- a/app/dashboard/profile/shared/bio.tsx
+++ b/app/dashboard/profile/shared/bio.tsx
@@ -1,0 +1,30 @@
+import { HStack, Text } from "@chakra-ui/react";
+export default function Bio({
+  bio,
+  truncate = true,
+}: {
+  bio: string;
+  truncate?: boolean;
+}) {
+  function renderBio() {
+    return truncate ? (
+      <Text lineClamp={6} lineHeight={"tall"} fontSize="large">
+        {bio}
+      </Text>
+    ) : (
+      <Text fontSize="large" lineHeight={"tall"}>
+        {bio}
+      </Text>
+    );
+  }
+  return bio ? (
+    renderBio()
+  ) : (
+    <HStack gap={1}>
+      {!bio && <Text>😶‍🌫️</Text>}
+      <Text lineHeight={"tall"} fontSize="large" fontStyle="italic">
+        This user has not added a bio.
+      </Text>
+    </HStack>
+  );
+}

--- a/app/dashboard/profile/shared/profile-header.tsx
+++ b/app/dashboard/profile/shared/profile-header.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { Avatar } from "@/app/shared/snippets/avatar";
+import { MenuTrigger } from "@/app/shared/snippets/menu";
+import { type Profile } from "@/app/swr/profile";
+import {
+  Stack,
+  HStack,
+  Text,
+  type UseDialogReturn,
+  Group,
+  IconButton,
+} from "@chakra-ui/react";
+import { LuEllipsis, LuMaximize2 } from "react-icons/lu";
+
+type ProfileHeaderProps = { profile: Profile } & (
+  | {
+      condensed: true;
+      setDialogOpen: UseDialogReturn["setOpen"];
+    }
+  | { condensed: false; setDialogOpen?: never }
+);
+export default function ProfileHeader({
+  profile,
+  condensed,
+  setDialogOpen,
+}: ProfileHeaderProps) {
+  const { image, name, degree } = profile;
+  return (
+    <HStack gap="3" p={0} justifyContent="space-between">
+      <Group>
+        <Avatar
+          src={image}
+          name={name}
+          bg="primary.contrast"
+          variant={"outline"}
+        />
+        <Stack gap="0">
+          <Text fontWeight="semibold" textStyle="sm">
+            {name}
+          </Text>
+          {degree?.degreeTypeCode && degree?.programName ? (
+            <Text
+              textStyle="sm"
+              lineClamp={1}
+            >{`${degree.degreeTypeCode} | ${degree.programName}`}</Text>
+          ) : (
+            <Text fontStyle={"italic"} fontSize={"sm"} lineHeight={1}>
+              degree unknown
+            </Text>
+          )}
+        </Stack>
+      </Group>
+      {condensed && (
+        <Group>
+          <IconButton
+            variant="subtle"
+            size="2xs"
+            rounded="full"
+            onClick={() => setDialogOpen(true)}
+          >
+            <LuMaximize2 />
+          </IconButton>
+          <MenuTrigger asChild>
+            <IconButton variant="subtle" size="2xs" rounded="full">
+              <LuEllipsis />
+            </IconButton>
+          </MenuTrigger>
+        </Group>
+      )}
+    </HStack>
+  );
+}

--- a/app/dashboard/profile/timeslot-row.tsx
+++ b/app/dashboard/profile/timeslot-row.tsx
@@ -1,0 +1,91 @@
+"use client";
+import { Slider } from "@/app/shared/snippets/slider";
+import { normalizeTimeslot } from "@/app/shared/util";
+import { type Timeslot } from "@/app/swr/profile";
+import { Table, Container } from "@chakra-ui/react";
+import React from "react";
+
+export default function TimeslotRow({ timeslot }: { timeslot: Timeslot }) {
+  const { from, to, reliability, flexibility } = normalizeTimeslot(timeslot);
+  console.log(timeslot);
+  return (
+    <Table.Row borderColor="accent.muted">
+      <Table.Cell borderColor="accent.muted">{from}</Table.Cell>
+      <Table.Cell borderColor="accent.muted">{to}</Table.Cell>
+      <Table.Cell borderColor="accent.muted" px={0}>
+        <Container display="flex" justifyContent={"center"}>
+          <Slider
+            size={"md"}
+            readOnly
+            step={50}
+            orientation={"vertical"}
+            height="100px"
+            colorPalette="gray"
+            thumbSize={{ width: 16, height: 16 }}
+            thumbAlignment="contain"
+            value={[reliability * 50]}
+            marks={[
+              { value: 0, label: "none" },
+              { value: 50, label: "" },
+              { value: 100, label: "max" },
+            ]}
+            hideFrom="md"
+          />
+          <Slider
+            size={"md"}
+            step={50}
+            width="150px"
+            colorPalette="gray"
+            readOnly
+            thumbSize={{ width: 16, height: 16 }}
+            thumbAlignment="contain"
+            value={[reliability * 50]}
+            marks={[
+              { value: 0, label: "none" },
+              { value: 50, label: "a little" },
+              { value: 100, label: "max" },
+            ]}
+            hideBelow="md"
+          />
+        </Container>
+      </Table.Cell>
+      <Table.Cell borderColor="accent.muted" px={0}>
+        <Container display="flex" justifyContent={"center"}>
+          <Slider
+            size={"md"}
+            readOnly
+            step={50}
+            orientation="vertical"
+            height="100px"
+            colorPalette="gray"
+            thumbSize={{ width: 16, height: 16 }}
+            thumbAlignment="contain"
+            value={[flexibility * 50]}
+            marks={[
+              { value: 0, label: "none" },
+              { value: 50, label: "" },
+              { value: 100, label: "max" },
+            ]}
+            hideFrom="md"
+          />
+          <Slider
+            size={"md"}
+            readOnly
+            step={50}
+            width="150px"
+            colorPalette="gray"
+            thumbSize={{ width: 16, height: 16 }}
+            thumbAlignment="contain"
+            value={[flexibility * 50]}
+            marks={[
+              { value: 0, label: "none" },
+              { value: 50, label: "a little" },
+              { value: 100, label: "max" },
+            ]}
+            hideBelow="md"
+          />{" "}
+        </Container>
+      </Table.Cell>
+    </Table.Row>
+  );
+}

--- a/app/dashboard/profile/timeslot-table.tsx
+++ b/app/dashboard/profile/timeslot-table.tsx
@@ -1,0 +1,77 @@
+"use client";
+import { Heading, Table, Card, useTabsContext } from "@chakra-ui/react";
+import React from "react";
+import { type Day, type Timeslot } from "../../swr/profile";
+import TimeslotRow from "./timeslot-row";
+function NoTimeslots() {
+  return (
+    <Card.Root size="sm" textAlign={"center"} border={0} bg="accent.muted/50">
+      <Card.Header>
+        <Heading size="md">nothing here! 👻</Heading>
+      </Card.Header>
+      <Card.Body>No study timeslots on this day.</Card.Body>
+    </Card.Root>
+  );
+}
+export default function TimeslotTable({
+  timeslotsMap,
+}: {
+  timeslotsMap: Record<Day, Timeslot[]>;
+}) {
+  const { value: day } = useTabsContext();
+  const timeslots = React.useMemo(
+    () => timeslotsMap[day as Day],
+    [timeslotsMap, day]
+  );
+  return timeslots?.length ? (
+    <Table.Root
+      size="sm"
+      variant="outline"
+      boxShadow={"0 0 0 0"}
+      colorPalette={"accent"}
+      shadow="xs"
+      rounded="md"
+      showColumnBorder
+    >
+      <Table.Header bg="accent.muted/50">
+        <Table.Row>
+          <Table.ColumnHeader
+            borderX="0"
+            borderColor="accent.muted"
+            textAlign={"center"}
+          >
+            From
+          </Table.ColumnHeader>
+          <Table.ColumnHeader
+            borderX="0"
+            borderColor="accent.muted"
+            textAlign={"center"}
+          >
+            To
+          </Table.ColumnHeader>
+          <Table.ColumnHeader
+            borderX="0"
+            borderColor="accent.muted"
+            textAlign={"center"}
+          >
+            Preference
+          </Table.ColumnHeader>
+          <Table.ColumnHeader
+            borderX="0"
+            borderColor="accent.muted"
+            textAlign={"center"}
+          >
+            Flexibility
+          </Table.ColumnHeader>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body bg="accent.muted/30">
+        {timeslots.map((item, index) => (
+          <TimeslotRow key={index} timeslot={item} />
+        ))}
+      </Table.Body>
+    </Table.Root>
+  ) : (
+    <NoTimeslots />
+  );
+}

--- a/app/dashboard/study-partners.tsx
+++ b/app/dashboard/study-partners.tsx
@@ -1,0 +1,93 @@
+"use client";
+import {
+  Tabs,
+  Card,
+  SimpleGrid,
+  GridItem,
+  Heading,
+  Spinner,
+  VStack,
+} from "@chakra-ui/react";
+import { LuFolder, LuSquareCheck, LuUser } from "react-icons/lu";
+import { useProfiles } from "../swr/profile";
+import { useSession } from "next-auth/react";
+import ProfileWrapper from "./profile/profile-wrapper";
+import FailedLoad from "../shared/failed-load";
+
+function AllProfiles() {
+  const { data: session, status: sessionStatus } = useSession();
+  const {
+    data: profiles,
+    isLoading,
+    error,
+  } = useProfiles(session?.accessToken, 1, 8);
+  if (sessionStatus === "loading" || isLoading)
+    return (
+      <VStack justifyContent={"center"} alignItems="center" height="100%">
+        <Spinner
+          size="xl"
+          width="10em"
+          height="10em"
+          color="accent.emphasized"
+          css={{ "--spinner-track-color": "colors.secondary" }}
+          borderWidth="4px"
+        />
+      </VStack>
+    );
+  if (error) return <FailedLoad />;
+  return (
+    <SimpleGrid
+      columns={[4]}
+      gap="1em"
+      width="min-fit"
+      alignItems={"center"}
+      justifyItems={"center"}
+    >
+      {profiles?.map((profile, index) => (
+        <GridItem key={index} colSpan={{ base: 4, lg: 2, xl: 1 }}>
+          <ProfileWrapper profile={profile} />
+        </GridItem>
+      ))}
+    </SimpleGrid>
+  );
+}
+export default function StudyPartners() {
+  return (
+    <Card.Root
+      width="100%"
+      variant={"elevated"}
+      bg={"secondary.muted"}
+      minHeight="80%"
+    >
+      <Card.Header textAlign={"center"} pb={0}>
+        <Heading size={"3xl"}>study partners</Heading>
+      </Card.Header>
+      <Card.Body gap="2">
+        <Tabs.Root defaultValue="search" variant={"line"} height="100%" py={3}>
+          <Tabs.List>
+            <Tabs.Trigger value="search">
+              <LuUser />
+              Search
+            </Tabs.Trigger>
+            <Tabs.Trigger value="projects">
+              <LuFolder />
+              Projects
+            </Tabs.Trigger>
+            <Tabs.Trigger value="tasks">
+              <LuSquareCheck />
+              Settings
+            </Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="search" alignItems={"center"} height="100%">
+            <AllProfiles />
+          </Tabs.Content>
+          <Tabs.Content value="projects">Manage your projects</Tabs.Content>
+          <Tabs.Content value="tasks">
+            Manage your tasks for freelancers
+          </Tabs.Content>
+        </Tabs.Root>
+      </Card.Body>
+      <Card.Footer justifyContent="flex-end"></Card.Footer>
+    </Card.Root>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,11 @@
+"use server";
+import { auth } from "@/auth";
 import { Heading } from "@chakra-ui/react";
+import { redirect } from "next/navigation";
 
-export default function Home() {
+export default async function Home() {
+  const session = await auth();
+  if (session) redirect("/dashboard");
   return (
     <>
       <Heading as="h1" size="6xl" letterSpacing={"wide"} textAlign={"center"}>
@@ -12,4 +17,3 @@ export default function Home() {
     </>
   );
 }
-// bird emoji is 🐦

--- a/app/profile/shared/util.ts
+++ b/app/profile/shared/util.ts
@@ -1,33 +1,12 @@
-import { type Timeslot } from "@/app/swr/profile";
-import dayjs from "dayjs";
-import objectSupport from "dayjs/plugin/objectSupport";
-import { TIME_REGEX } from "./constants";
-dayjs.extend(objectSupport);
-
+import { type UnknownArray } from "type-fest";
 /**
- * Normalizes times shown in timeslot to 12-hour clock format.
- * @param timeslot A timeslot with `from` and `to` times written in 24-hour clock format
- * @returns A timeslot with `from` and `to` times written in 12-hour clock format.
+ * Counts occurrences of value in array
+ * @param array The array to evaluate
+ * @param target The target value
+ * @returns The count of occurrences
  */
-export function normalizeTimeslot(timeslot: Timeslot) {
-  const { from, to, ...rest } = timeslot;
-  if (from.match(TIME_REGEX)) {
-    // If timeslots already formatted correctly, no need to reformat
-    return {
-      ...rest,
-      from,
-      to,
-    };
-  }
-  return {
-    ...rest,
-    from: dayjs({
-      hour: from.split(":")[0],
-      minute: from.split(":")[1],
-    }).format("hh:mm A"),
-    to: dayjs({
-      hour: to.split(":")[0],
-      minute: to.split(":")[1],
-    }).format("hh:mm A"),
-  };
+export function countOccurrencesInArray(array: UnknownArray, target: unknown) {
+  return array.reduce((acc: number, currentValue: unknown) => {
+    return currentValue === target ? acc + 1 : acc;
+  }, 0);
 }

--- a/app/shared/util.ts
+++ b/app/shared/util.ts
@@ -1,0 +1,34 @@
+import dayjs from "dayjs";
+import objectSupport from "dayjs/plugin/objectSupport";
+import { TIME_REGEX } from "../profile/shared/constants";
+import type { Timeslot } from "../swr/profile";
+dayjs.extend(objectSupport);
+
+/**
+ * Normalizes times shown in timeslot to 12-hour clock format.
+ * @param timeslot A timeslot with `from` and `to` times written in 24-hour clock format
+ * @returns A timeslot with `from` and `to` times written in 12-hour clock format.
+ */
+export function normalizeTimeslot(timeslot: Timeslot) {
+  const { from, to, ...rest } = timeslot;
+  if (from.match(TIME_REGEX)) {
+    // If timeslots already formatted correctly, no need to reformat
+    return {
+      ...rest,
+      from,
+      to,
+    };
+  }
+
+  return {
+    ...rest,
+    from: dayjs({
+      hour: from.split(":")[0],
+      minute: from.split(":")[1],
+    }).format("hh:mm A"),
+    to: dayjs({
+      hour: to.split(":")[0],
+      minute: to.split(":")[1],
+    }).format("hh:mm A"),
+  };
+}

--- a/app/swr/profile.ts
+++ b/app/swr/profile.ts
@@ -91,6 +91,30 @@ export function useSelfProfile(accessToken: string | undefined) {
 
   return {
     data,
+    mutate,
+    error,
+    isLoading,
+  };
+}
+
+export function useProfiles(
+  accessToken: string | undefined,
+  page: number = 1,
+  size: number = 8
+) {
+  const { data, error, isLoading } = useSWR<Profile[]>(
+    fetchCheck(
+      !!accessToken,
+      accessToken,
+      `/profile?page=${encodeURIComponent(page)}&size=${encodeURIComponent(size)}`
+    ),
+    ([url, accessToken]: [url: string, accessToken: string]) =>
+      fetcher(url, accessToken),
+    defaultOptions
+  );
+
+  return {
+    data,
     error,
     isLoading,
   };


### PR DESCRIPTION
Per FLOC-58, this PR creates a 'dashboard' page for logged-in users. This is the page users are redirected to upon logging in, and it is the homepage for logged-in users. Currently, the dashboard page only has a "study partners" section, which will be extended to permit profile searches per FLOC-51.
