### PR TITLE
FLOC-59: Refactor code to root layout, improve theming

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import { Provider as ColorModeProvider } from "@/app/shared/snippets/provider";
 import Header from "@/app/shared/header";
 import type { Metadata } from "next";
-import { Montserrat_Alternates, Questrial, Arvo } from "next/font/google";
+import { Montserrat_Alternates, Questrial } from "next/font/google";
 import Footer from "@/app/shared/footer";
 import { Toaster } from "./shared/snippets/toaster";
 import { SessionProvider } from "next-auth/react";
@@ -13,11 +13,6 @@ const montserrat = Montserrat_Alternates({
   weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
 });
 
-const arvo = Arvo({
-  variable: "--arvo",
-  subsets: ["latin"],
-  weight: ["400", "700"],
-});
 const questrial = Questrial({
   variable: "--font-questrial",
   subsets: ["latin"],
@@ -36,7 +31,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${montserrat.variable} ${arvo.variable} ${questrial.variable}`}
+        className={`${montserrat.variable} ${questrial.variable}`}
         style={{
           display: "flex",
           flexDirection: "column",

--- a/app/shared/failed-load.tsx
+++ b/app/shared/failed-load.tsx
@@ -1,0 +1,16 @@
+import { VStack } from "@chakra-ui/react";
+import { LuFrown } from "react-icons/lu";
+
+export default function FailedLoad({ description }: { description?: string }) {
+  return (
+    <VStack
+      alignItems={"center"}
+      justifyContent={"center"}
+      width="100%"
+      height="100%"
+    >
+      <LuFrown size={"100px"} stroke="darkorange" />
+      <h1>{description ? description : "failed to load"}</h1>
+    </VStack>
+  );
+}

--- a/app/shared/header.tsx
+++ b/app/shared/header.tsx
@@ -11,7 +11,8 @@ import {
   Badge,
   LinkOverlay,
   LinkBox,
-  PopoverCloseTrigger,
+  usePopover,
+  PopoverRootProvider,
 } from "@chakra-ui/react";
 import { ColorModeButton } from "./snippets/color-mode";
 import { useState } from "react";
@@ -20,7 +21,6 @@ import { ringCss } from "@/theme";
 import {
   PopoverBody,
   PopoverContent,
-  PopoverRoot,
   PopoverTrigger,
 } from "./snippets/popover";
 import { Tag } from "./snippets/tag";
@@ -30,7 +30,6 @@ import { signIn } from "../actions/signin";
 import { useSession } from "next-auth/react";
 import { type Profile, useSelfProfile } from "../swr/profile";
 import { toaster } from "./snippets/toaster";
-import { useRouter } from "next/navigation";
 function LoginButton() {
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const trigger = (
@@ -70,10 +69,10 @@ function LoginButton() {
 function Welcome({ user }: { user: Profile }) {
   const firstName = user.name!.split(" ")[0];
   const { degree, name, image, roles, standing, campusChoices } = user;
-  const router = useRouter();
+  const popover = usePopover();
   return (
     <Box>
-      <PopoverRoot>
+      <PopoverRootProvider value={popover}>
         <PopoverTrigger
           _hover={{
             bg: "secondary.emphasized",
@@ -108,7 +107,12 @@ function Welcome({ user }: { user: Profile }) {
             </Text>
           </HStack>{" "}
         </PopoverTrigger>
-        <PopoverContent width="100%" bg="secondary" aria-label="User Info">
+        <PopoverContent
+          portalled={false}
+          width="100%"
+          bg="secondary"
+          aria-label="User Info"
+        >
           <PopoverBody>
             <VStack
               alignItems={"center"}
@@ -186,16 +190,26 @@ function Welcome({ user }: { user: Profile }) {
                 </Tag>
               </HStack>
               <HStack gap={10}>
-                <PopoverCloseTrigger asChild>
-                  <Button
-                    variant={"subtle"}
-                    colorPalette={"accent"}
-                    size="xs"
-                    onClick={() => router.push("/profile")}
+                <Button
+                  variant={"subtle"}
+                  colorPalette={"accent"}
+                  size="xs"
+                  p={0}
+                  onClick={() => popover.setOpen(false)}
+                >
+                  <Link
+                    href="/profile"
+                    style={{
+                      height: "100%",
+                      width: "100%",
+                      padding: "8px 16px",
+                      textAlign: "center",
+                    }}
+                    prefetch={true}
                   >
-                    Edit Profile{" "}
-                  </Button>
-                </PopoverCloseTrigger>
+                    Edit Profile
+                  </Link>
+                </Button>
                 <LinkBox>
                   <Button
                     variant={"solid"}
@@ -213,7 +227,7 @@ function Welcome({ user }: { user: Profile }) {
             </VStack>
           </PopoverBody>
         </PopoverContent>
-      </PopoverRoot>
+      </PopoverRootProvider>
     </Box>
   );
 }

--- a/app/shared/snippets/accordion.tsx
+++ b/app/shared/snippets/accordion.tsx
@@ -1,4 +1,4 @@
-import { Accordion, HStack } from "@chakra-ui/react";
+import { Accordion, HStack, Icon } from "@chakra-ui/react";
 import * as React from "react";
 import { LuChevronDown } from "react-icons/lu";
 
@@ -15,15 +15,17 @@ export const AccordionItemTrigger = React.forwardRef<
     <Accordion.ItemTrigger {...rest} ref={ref}>
       {indicatorPlacement === "start" && (
         <Accordion.ItemIndicator rotate={{ base: "-90deg", _open: "0deg" }}>
-          <LuChevronDown />
+          <LuChevronDown color="fg" />
         </Accordion.ItemIndicator>
       )}
       <HStack gap="4" flex="1" textAlign="start" width="full">
         {children}
       </HStack>
       {indicatorPlacement === "end" && (
-        <Accordion.ItemIndicator>
-          <LuChevronDown />
+        <Accordion.ItemIndicator asChild>
+          <Icon color="colorPalette">
+            <LuChevronDown />
+          </Icon>
         </Accordion.ItemIndicator>
       )}
     </Accordion.ItemTrigger>

--- a/app/shared/snippets/menu.tsx
+++ b/app/shared/snippets/menu.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { AbsoluteCenter, Menu as ChakraMenu, Portal } from "@chakra-ui/react"
+import * as React from "react"
+import { LuCheck, LuChevronRight } from "react-icons/lu"
+
+interface MenuContentProps extends ChakraMenu.ContentProps {
+  portalled?: boolean
+  portalRef?: React.RefObject<HTMLElement>
+}
+
+export const MenuContent = React.forwardRef<HTMLDivElement, MenuContentProps>(
+  function MenuContent(props, ref) {
+    const { portalled = true, portalRef, ...rest } = props
+    return (
+      <Portal disabled={!portalled} container={portalRef}>
+        <ChakraMenu.Positioner>
+          <ChakraMenu.Content ref={ref} {...rest} />
+        </ChakraMenu.Positioner>
+      </Portal>
+    )
+  },
+)
+
+export const MenuArrow = React.forwardRef<
+  HTMLDivElement,
+  ChakraMenu.ArrowProps
+>(function MenuArrow(props, ref) {
+  return (
+    <ChakraMenu.Arrow ref={ref} {...props}>
+      <ChakraMenu.ArrowTip />
+    </ChakraMenu.Arrow>
+  )
+})
+
+export const MenuCheckboxItem = React.forwardRef<
+  HTMLDivElement,
+  ChakraMenu.CheckboxItemProps
+>(function MenuCheckboxItem(props, ref) {
+  return (
+    <ChakraMenu.CheckboxItem ps="8" ref={ref} {...props}>
+      <AbsoluteCenter axis="horizontal" insetStart="4" asChild>
+        <ChakraMenu.ItemIndicator>
+          <LuCheck />
+        </ChakraMenu.ItemIndicator>
+      </AbsoluteCenter>
+      {props.children}
+    </ChakraMenu.CheckboxItem>
+  )
+})
+
+export const MenuRadioItem = React.forwardRef<
+  HTMLDivElement,
+  ChakraMenu.RadioItemProps
+>(function MenuRadioItem(props, ref) {
+  const { children, ...rest } = props
+  return (
+    <ChakraMenu.RadioItem ps="8" ref={ref} {...rest}>
+      <AbsoluteCenter axis="horizontal" insetStart="4" asChild>
+        <ChakraMenu.ItemIndicator>
+          <LuCheck />
+        </ChakraMenu.ItemIndicator>
+      </AbsoluteCenter>
+      <ChakraMenu.ItemText>{children}</ChakraMenu.ItemText>
+    </ChakraMenu.RadioItem>
+  )
+})
+
+export const MenuItemGroup = React.forwardRef<
+  HTMLDivElement,
+  ChakraMenu.ItemGroupProps
+>(function MenuItemGroup(props, ref) {
+  const { title, children, ...rest } = props
+  return (
+    <ChakraMenu.ItemGroup ref={ref} {...rest}>
+      {title && (
+        <ChakraMenu.ItemGroupLabel userSelect="none">
+          {title}
+        </ChakraMenu.ItemGroupLabel>
+      )}
+      {children}
+    </ChakraMenu.ItemGroup>
+  )
+})
+
+export interface MenuTriggerItemProps extends ChakraMenu.ItemProps {
+  startIcon?: React.ReactNode
+}
+
+export const MenuTriggerItem = React.forwardRef<
+  HTMLDivElement,
+  MenuTriggerItemProps
+>(function MenuTriggerItem(props, ref) {
+  const { startIcon, children, ...rest } = props
+  return (
+    <ChakraMenu.TriggerItem ref={ref} {...rest}>
+      {startIcon}
+      {children}
+      <LuChevronRight />
+    </ChakraMenu.TriggerItem>
+  )
+})
+
+export const MenuRadioItemGroup = ChakraMenu.RadioItemGroup
+export const MenuContextTrigger = ChakraMenu.ContextTrigger
+export const MenuRoot = ChakraMenu.Root
+export const MenuSeparator = ChakraMenu.Separator
+
+export const MenuItem = ChakraMenu.Item
+export const MenuItemText = ChakraMenu.ItemText
+export const MenuItemCommand = ChakraMenu.ItemCommand
+export const MenuTrigger = ChakraMenu.Trigger

--- a/app/signout/page.tsx
+++ b/app/signout/page.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { Container, Stack, Text } from "@chakra-ui/react";
 import AnimatedDialog from "../shared/animated-dialog";
+import { Text } from "@chakra-ui/react";
 import { useEffect } from "react";
 import { signOut } from "next-auth/react";
 
@@ -9,33 +9,19 @@ export default function SignOut() {
     signOut({ redirect: true, redirectTo: "/" });
   }, []);
   return (
-    <Container
-      as="main"
-      w="100%"
-      maxW="100%"
-      flex={1}
-      flexDir={"column"}
-      alignItems={"stretch"}
-      justifyContent={"stretch"}
-      py={5}
-      px={5}
-    >
-      <Stack as="section" h="100%">
-        <AnimatedDialog
-          animationName="birdloader"
-          open={true}
-          content={
-            <Text
-              fontSize="lg"
-              letterSpacing={"wide"}
-              textAlign={"center"}
-              lineHeight={1.2}
-            >
-              Thanks for stopping by!
-            </Text>
-          }
-        ></AnimatedDialog>
-      </Stack>
-    </Container>
+    <AnimatedDialog
+      animationName="birdloader"
+      open={true}
+      content={
+        <Text
+          fontSize="lg"
+          letterSpacing={"wide"}
+          textAlign={"center"}
+          lineHeight={1.2}
+        >
+          Thanks for stopping by!
+        </Text>
+      }
+    />
   );
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ["@chakra-ui/react"],
   },
+  reactStrictMode: false,
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "next-themes": "^0.4.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-icons": "^5.4.0",
+        "react-icons": "^5.5.0",
         "swr": "^2.3.2"
       },
       "devDependencies": {
@@ -5572,9 +5572,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
-      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.4.0",
+    "react-icons": "^5.5.0",
     "swr": "^2.3.2"
   },
   "devDependencies": {

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -2,7 +2,6 @@ import {
   createSystem,
   defaultConfig,
   defineConfig,
-  defineRecipe,
   defineSemanticTokens,
   defineStyle,
   defineTokens,
@@ -310,8 +309,8 @@ const colorSemanticTokens = defineSemanticTokens({
       },
       emphasized: {
         value: {
-          _light: "{colors.secondaryLight.300}",
-          _dark: "{colors.secondaryDark.900}",
+          _light: "{colors.secondaryLight.400}",
+          _dark: "{colors.secondaryDark.800}",
         },
       },
       panel: {
@@ -329,23 +328,7 @@ const colorSemanticTokens = defineSemanticTokens({
     },
   },
 });
-const headingRecipe = defineRecipe({
-  variants: {
-    size: {
-      xl: {
-        fontFamily: "Arvo",
-      },
 
-      "2xl": {
-        fontFamily: "Arvo",
-      },
-
-      "3xl": {
-        fontFamily: "Arvo",
-      },
-    },
-  },
-});
 const theme = defineConfig({
   theme: {
     tokens: {
@@ -358,9 +341,6 @@ const theme = defineConfig({
         },
       },
       ...colorTokens,
-    },
-    recipes: {
-      heading: { ...defaultConfig.theme?.recipes?.heading, ...headingRecipe },
     },
     semanticTokens: { ...colorSemanticTokens },
   },


### PR DESCRIPTION
Per FLOC-59, this PR makes some miscellaneous improvements to the frontend's design. Firstly, most pages have the same code surrounding the actual page (a combination of <Container> and <Stack> components). These are now refactored out to the root layout. Secondly, snippets from previous changes are added in. Thirdly, Arvo is removed from the theme because it clashes too much with the other fonts. Fourthly, React Strict Mode is disabled.
