### PR TITLE
Remove doppler references from `build` and `start` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "doppler run -- npx next dev",
-    "build": "doppler run -- npx next build",
-    "start": "doppler run -- npx next start",
+    "build": "next build",
+    "start": "next start",
     "lint": "next lint",
     "prepare": "husky"
   },


### PR DESCRIPTION
Per FLOC-61, this PR fixes failing Vercel deployments due to the `doppler` reference in the `start` and `build` scripts in package.json
