### PR TITLE
Fix bug causing auth failure after .env removal

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -26,8 +26,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     // based on guide: https://authjs.dev/guides/integrating-third-party-backends#storing-the-token-in-the-session
     async jwt({ token, account, trigger, user }) {
       if ((trigger === "signIn" || trigger === "signUp") && !!account) {
-        console.log(account);
-        fetch(`${process.env.API_URL!}/profile/me`, {
+        fetch(`${process.env.NEXT_PUBLIC_API_URL!}/profile/me`, {
           method: "POST",
           headers: {
             Authorization: `Bearer ${account?.access_token}`,

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,15 @@
 import { auth } from "@/auth";
+import { NextResponse } from "next/server";
 
 export const config = {
-  matcher: "/((?!$))",
+  matcher: [
+    "/((?!api|_next/static|_next/image|unauthorized|signin|favicon.ico|robots.txt|images|$).*)",
+  ],
 };
-export default auth((req): Response | undefined => {
-  if (!req.auth && req.nextUrl.pathname !== "/login") {
+export default auth((req) => {
+  if (!req.auth) {
     const newUrl = new URL("/unauthorized", req.nextUrl.origin);
-    return Response.redirect(newUrl);
+    return NextResponse.redirect(newUrl);
   }
+  return NextResponse.next();
 });


### PR DESCRIPTION
Initially, a .env file was used locally, but Doppler has since replaced its functionality. Now, the .env file was removed to clean unnecessary files up, but the authentication mechanism suddenly fails. This PR fixes the issue.